### PR TITLE
Add 'type' attribute to the link tag

### DIFF
--- a/sage-fonts-preload.php
+++ b/sage-fonts-preload.php
@@ -15,8 +15,9 @@ add_filter('wp_head', function () {
     })->map(function ($item) {
         // Return asset uri without versioning query string
         return sprintf(
-            '<link rel="preload" href="%s" as="font" crossorigin>',
-            substr(asset($item)->uri(), 0, strpos(asset($item)->uri(), '?id='))
+            '<link rel="preload" href="%s" type="font/%s" as="font" crossorigin>',
+            substr(asset($item)->uri(), 0, strpos(asset($item)->uri(), '?id=')),
+            pathinfo($item, PATHINFO_EXTENSION)
         );
     })->implode("\n");
 });


### PR DESCRIPTION
I encountered a issue with this package, the browser (Chrome 96) would request both the woff and woff2 files of the same font, when only the woff2 font would be necessary.

This issue can be resolved by adding the 'type' attribute to the <link> ([https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload#including_a_mime_type](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload#including_a_mime_type))

The changes in this PR should fix this issue.